### PR TITLE
lazy load images and pre-load blurry images

### DIFF
--- a/src/squelettes/modeles/img_responsive.html
+++ b/src/squelettes/modeles/img_responsive.html
@@ -14,7 +14,7 @@
 #SET{fichier,#URL_DOCUMENT}
 
 [<!--(#REM) générer le doc avant loading-->]
-#SET{mini_fichier,#GET{fichier}|image_reduire{7,0}}
+#SET{pico_fichier,#GET{fichier}|image_reduire{7,0}}
 
 #SET{url,#ENV{lien}}
 [<!--(#REM)

--- a/src/squelettes/modeles/img_responsive.html
+++ b/src/squelettes/modeles/img_responsive.html
@@ -12,6 +12,10 @@
 -->]
 
 #SET{fichier,#URL_DOCUMENT}
+
+[<!--(#REM) générer le doc avant loading-->]
+#SET{mini_fichier,#GET{fichier}|image_reduire{7,0}}
+
 #SET{url,#ENV{lien}}
 [<!--(#REM)
 


### PR DESCRIPTION
Let's optimise page loading by using a pico-format on first load, then replace them lazily with responsive images